### PR TITLE
Different response

### DIFF
--- a/programming_fundamentals/python_part_3/api_requests_example.py
+++ b/programming_fundamentals/python_part_3/api_requests_example.py
@@ -34,5 +34,5 @@ r = requests.get(u,
 pprint(r.text)
 
 api_data = r.json()
-interface_name = api_data["ietf-interfaces:interface"]["name"]
+interface_name = api_data["Cisco-IOS-XE-interfaces-oper:interface"]["name"]
 interface_name


### PR DESCRIPTION
JSON response from the sandbox device starts with "Cisco-IOS-XE-interfaces-oper:interface", not "ietf-interfaces:interface".