### PR TITLE
Correcting "Name"

### DIFF
--- a/network_device_apis/netconf/example2.py
+++ b/network_device_apis/netconf/example2.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
 
         print("")
         print("Interface Details:")
-        print("  Name: {}".format(intf_config["name"]))
+        print("  Name: {}".format(intf_config["name"]["#text"]))
         print("  Description: {}".format(intf_config["description"]))
         print("  Type: {}".format(intf_config["type"]["#text"]))
         print("  MAC Address: {}".format(intf_info["phys-address"]))


### PR DESCRIPTION
The original python file generates an incorrect "Name:" field:

```
python example2.py                            

Interface Details:
  Name: OrderedDict([(u'@xmlns:nc', u'urn:ietf:params:xml:ns:netconf:base:1.0'), ('#text', u'GigabitEthernet2')])
  Description: Configured by DIYERS
  Type: ianaift:ethernetCsmacd
  MAC Address: 00:50:56:bb:ac:30
  Packets Input: 56
  Packets Output: 3
```

With the proposed change it provides the correct output:

```
python example2.py                             

Interface Details:
  Name: GigabitEthernet2
  Description: Configured by DIYERS
  Type: ianaift:ethernetCsmacd
  MAC Address: 00:50:56:bb:ac:30
  Packets Input: 56
  Packets Output: 3
```