### PR TITLE
Change ncclient version to make it work with python 3.7

### DIFF
--- a/programming_fundamentals/python_part_3/requirements.txt
+++ b/programming_fundamentals/python_part_3/requirements.txt
@@ -1,4 +1,4 @@
-ncclient==0.5.3
+ncclient==0.6.3
 netmiko==1.4.2
 PyYAML==3.12
 requests==2.18.2


### PR DESCRIPTION
The specified ncclient version (0.5.3) does not work with python 3.7, so it needs to be updated to the latest 0.6.3 to work just fine with the NETCONF example in this section.