### PR TITLE
Dev Sandbox move from http to https

### DIFF
--- a/network_device_apis/nxapi/sbx_setup.py
+++ b/network_device_apis/nxapi/sbx_setup.py
@@ -19,7 +19,7 @@ import requests
 import json
 
 # Switch Connection Info
-url = 'http://10.10.20.58/ins'
+url = 'https://10.10.20.58/ins'
 switchuser = 'admin'
 switchpassword = 'cisco123'
 myheaders = {'content-type': 'application/json'}
@@ -41,5 +41,6 @@ response = requests.post(
                           url,
                           data=json.dumps(payload),
                           headers=myheaders,
-                          auth=(switchuser, switchpassword)
+                          auth=(switchuser, switchpassword),
+                          verify=False
                          ).json()


### PR DESCRIPTION
The developer sandbox in the ‘Open NX-OS with Nexus 9K’ sandbox is only accessible via https (not http), so need to change this setup file.