### PR TITLE
Postman config change Eth1/1 to Eth1/4 (NX-API)

### DIFF
--- a/postman_config/Network Programmability Basics.postman_collection.json
+++ b/postman_config/Network Programmability Basics.postman_collection.json
@@ -1335,7 +1335,7 @@
 					"response": []
 				},
 				{
-					"name": "GET Interface Eth1/1",
+					"name": "GET Interface Eth1/4",
 					"request": {
 						"method": "GET",
 						"header": [],
@@ -1344,7 +1344,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://{{host}}/api/node/mo/sys/intf/phys-[eth1/1].json",
+							"raw": "https://{{host}}/api/node/mo/sys/intf/phys-[eth1/4].json",
 							"protocol": "https",
 							"host": [
 								"{{host}}"
@@ -1363,7 +1363,7 @@
 					"response": []
 				},
 				{
-					"name": "PUT Interface Eth1/1 - Desc",
+					"name": "PUT Interface Eth1/4 - Desc",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1372,7 +1372,7 @@
 							"raw": "{\n    \"l1PhysIf\": {\n        \"attributes\": {\n            \"descr\": \"Configured with NX-API REST\"\n        }\n    }\n}"
 						},
 						"url": {
-							"raw": "https://{{host}}/api/node/mo/sys/intf/phys-[eth1/1].json",
+							"raw": "https://{{host}}/api/node/mo/sys/intf/phys-[eth1/4].json",
 							"protocol": "https",
 							"host": [
 								"{{host}}"


### PR DESCRIPTION
When trying to add a description to Eth1/1 in NX-OS sandbox, it fails because the default setup sets Eth1/1 in a port channel:

```
ERROR: : port already in a port-channel, no config allowed
```

So let's configure Eth1/4 instead, and everything works fine.