### PR TITLE
Change shebang in all 11 Python example scripts?

### DIFF
--- a/programming_fundamentals/python_part_1/example1.py
+++ b/programming_fundamentals/python_part_1/example1.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 """
 Learning Series: Network Programmability Basics
 Module: Programming Fundamentals


### PR DESCRIPTION
Have you considered changing the shebang in each Python example script (11 in total across the 3 Python parts).

from 

#! /usr/bin/env python

to 

#!/usr/bin/env python3