### PR TITLE
Examples on curl_examples.sh not working

### DIFF
--- a/programming_fundamentals/rest_part_1/curl_examples.sh
+++ b/programming_fundamentals/rest_part_1/curl_examples.sh
@@ -19,3 +19,9 @@ curl -vk \
   -u developer:C1sco12345 \
   -H 'accept: application/yang-data+json' \
   https://ios-xe-mgmt.cisco.com:9443/restconf/data/ietf-interfaces:interfaces/interface=GigabitEthernet2
+  
+  
+  
+"""
+see Pull Request for details
+"""


### PR DESCRIPTION
    Unfortunately, the Chuck Norris API introduced at around 18:24 of the video is no longer online….

    https://developer.cisco.com/video/net-prog-basics/01-programming_fundamentals/rest_part_1/curl_examples.sh
    

    …and it’s referenced as well in the GitHub repo here…

    https://github.com/CiscoDevNet/netprog_basics/blob/master/programming_fundamentals/rest_part_1/curl_examples.sh

   
   We could replace the Chuck Norris API with something like the Dog API (https://dog.ceo/dog-api/):
   

    curl https://dog.ceo/api/breeds/image/random

    {"message":"https:\/\/images.dog.ceo\/breeds\/dane-great\/n02109047_20023.jpg","status":"success"}

    curl https://dog.ceo/api/breed/hound/images/random

    {"message":"https:\/\/images.dog.ceo\/breeds\/hound-basset\/n02088238_305.jpg","status":"success"}



    …in regards to this curl_examples.sh file, the Network Programmability with RESTCONF example cURL on lines 17-21 will not work as written. However, if we change the URL to either of these two, it will work:

    sandbox-iosxe-latest-1.cisco.com
    sandbox-iosxe-recomm-1.cisco.com

    So, the video doesn’t need to be updated, but the curl_examples.sh file does, because at 31:11 Hank urges the users to go back and run these code examples.